### PR TITLE
added Method#to_proc

### DIFF
--- a/mrblib/method.rb
+++ b/mrblib/method.rb
@@ -10,6 +10,10 @@ class Method
   def call(*args)
     @recv.__send__(@id, *args)
   end
+  
+  def to_proc
+    proc {|*args| self.call(*args)}
+  end
 
   def owner
     @owner


### PR DESCRIPTION
Its now possible to use &method(:name) as a block parameter.
