### PR TITLE
Allow to call super via Method#call

### DIFF
--- a/src/method.c
+++ b/src/method.c
@@ -59,13 +59,19 @@ static mrb_value
 method_call(mrb_state *mrb, mrb_value self)
 {
   mrb_value proc = mrb_iv_get(mrb, self, mrb_intern_lit(mrb, "@proc"));
+  mrb_value name = mrb_iv_get(mrb, self, mrb_intern_lit(mrb, "@name"));
   mrb_value recv = mrb_iv_get(mrb, self, mrb_intern_lit(mrb, "@recv"));
   struct RClass *owner = mrb_class_ptr(mrb_iv_get(mrb, self, mrb_intern_lit(mrb, "@owner")));
   mrb_int argc;
-  mrb_value *argv;
+  mrb_value *argv, ret;
+  mrb_sym orig_mid;
 
   mrb_get_args(mrb, "*", &argv, &argc);
-  return mrb_yield_with_class(mrb, proc, argc, argv, recv, owner);
+  orig_mid = mrb->c->ci->mid;
+  mrb->c->ci->mid = mrb_symbol(name);
+  ret = mrb_yield_with_class(mrb, proc, argc, argv, recv, owner);
+  mrb->c->ci->mid = orig_mid;
+  return ret;
 }
 
 static mrb_value

--- a/test/method.rb
+++ b/test/method.rb
@@ -78,6 +78,13 @@ end
 assert 'Method#call' do
   assert_equal 3, 1.method(:+).call(2)
   assert_equal "ab", "a".method(:+)["b"]
+  klass = Class.new {
+    def foo; 42; end
+  }
+  klass2 = Class.new(klass) {
+    def foo; super; end
+  }
+  assert_equal 42, klass2.new.method(:foo).call
   # TODO: suppert with block
   # i = Class.new {
   #  def bar


### PR DESCRIPTION
Hello,

When a method is called via `Method#call`, it fails to call super.

```
class C
  def foo
    p C
  end
end

class D < C
  def foo
    p D
    super
  end
end

D.new.method(:foo).call
```

```
$ ./bin/mruby t.rb
D
trace:
        [0] t.rb:10:in D.call
        [1] t.rb:14
t.rb:10: undefined method 'call' for #<D:0x16b5f70> (NoMethodError)
```

This PR allows to call super.

```
$ ./bin/mruby t.rb
D
C
```
