### PR TITLE
Some fixes for minirake(tsort).

### DIFF
--- a/mrblib/method.rb
+++ b/mrblib/method.rb
@@ -1,8 +1,8 @@
 class Method
   def to_proc
     m = self
-    lambda { |*args|
-      m.call(*args)
+    lambda { |*args, &b|
+      m.call(*args, &b)
     }
   end
 

--- a/src/method.c
+++ b/src/method.c
@@ -120,7 +120,7 @@ method_call(mrb_state *mrb, mrb_value self)
   orig_mid = mrb->c->ci->mid;
   mrb->c->ci->mid = mrb_symbol(name);
   if (mrb_nil_p(proc)) {
-    mrb_value *missing_argv = alloca(sizeof(mrb_value) * (argc + 1));
+    mrb_value *missing_argv = (mrb_value*)alloca(sizeof(mrb_value) * (argc + 1));
     missing_argv[0] = name;
     for(i = 0; i < argc; i++) {
       missing_argv[i + 1] = argv[i];

--- a/test/method.rb
+++ b/test/method.rb
@@ -139,6 +139,8 @@ assert 'Method#call with undefined method' do
 end
 
 assert 'Method#source_location' do
+  skip if proc{}.source_location.nil?
+
   filename = __FILE__
   klass = Class.new
 
@@ -155,6 +157,8 @@ assert 'Method#source_location' do
 end
 
 assert 'UnboundMethod#source_location' do
+  skip if proc{}.source_location.nil?
+
   filename = __FILE__
   klass = Class.new {
     def respond_to_missing?(m, b)

--- a/test/method.rb
+++ b/test/method.rb
@@ -374,7 +374,7 @@ assert 'UnboundMethod#arity' do
     end
   }
   assert_equal 2, c.instance_method(:foo).arity
-  assert_equal -1, c.new.method(:nothing).unbind.arity
+  assert_equal(-1, c.new.method(:nothing).unbind.arity)
 end
 
 assert 'UnboundMethod#==' do

--- a/test/method.rb
+++ b/test/method.rb
@@ -90,14 +90,14 @@ assert 'Method#call' do
     def foo; super; end
   }
   assert_equal 42, klass2.new.method(:foo).call
-  # TODO: suppert with block
-  # i = Class.new {
-  #  def bar
-  #    yield 3
-  #  end
-  # }.new
-  # assert_raise(LocalJumpError) { i.method(:bar).call }
-  # assert_equal 3, i.method(:bar).call { |i| i }
+
+  i = Class.new {
+   def bar
+     yield 3
+   end
+  }.new
+  assert_raise(LocalJumpError) { i.method(:bar).call }
+  assert_equal 3, i.method(:bar).call { |i| i }
 end
 
 assert 'Method#call for regression' do
@@ -272,10 +272,16 @@ assert 'Method#unbind' do
     def foo() :changed end
   end
   assert_equal(:changed, Derived.new.foo)
+  assert_equal(:changed, Derived.new.foo{})
   assert_equal(:derived, um.bind(Derived.new).call)
   assert_raise(TypeError) do
     um.bind(Base.new)
   end
+
+  # TODO:
+  #  Block passed method not handled correctly with workaround.
+  #  See comment near `mrb_funcall_with_block` for detail.
+  # assert_equal(:derived, um.bind(Derived.new).call{})
 end
 
 assert 'Kernel#method' do


### PR DESCRIPTION
Maybe we need the API to call block with block argument like:
```C
MRB_API mrb_value mrb_yield_with_block(mrb_state *mrb, mrb_value b, mrb_int argc, const mrb_value *argv, mrb_value self, struct RClass *c, mrb_value block);
```
